### PR TITLE
PR: Streamed Summary + Quiz (NDJSON)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,5 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+test.txt

--- a/README.md
+++ b/README.md
@@ -35,19 +35,19 @@ This project demonstrates **end-to-end AI application development** using modern
 - **Modular, testable pipeline architecture**
 - **Async and parallel processing** readiness for large workloads
 - **Frontend-backend API integration**
-- **Environment configuration & secret management**
+- **Streaming via OpenAI** for smooth, immediate feedback.
 
 ## 🔮 Future Enhancements
 
 Planned improvements to showcase advanced LangChain + AI engineering skills:
 
-- **Streaming LLM responses** for real-time summary/quiz rendering
 - **Parallel chunk processing** for faster large-document summarization
 - **LangSmith tracing** for debugging and performance insights
 - **Custom prompt injection defenses** via system/human role structuring
 - **Vector search integration** for context-aware summarization
 - **Document handling** for .docx, .txt, etc. upload
 - **Deployment** of both backend and frontend with user uploaded API key
+- **Automated testing** for scalability and reliability
 
 ## 📂 Repositories
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -10,6 +10,8 @@ This is the backend API for the **TLDR** app — a summarization and quiz genera
 - **Structured JSON output** guaranteed to match schemas
 - **Prompt engineering** for engaging, scannable summaries (sections, bullet points, emojis)
 - **Clean modular design**: `summarize_text()` and `generate_quiz()` are isolated for maintainability
+- **Streaming responses** for real-time summary delivery
+
 
 ## 🛠️ Tech Stack
 
@@ -57,7 +59,6 @@ uvicorn app.main:app --reload --port 8000
 ```
 
 ## 🔮 Future Enhancements
-- Streaming responses for real-time summary delivery
 - Parallel chunk processing
 - LangSmith tracing for debugging & metrics
 - API key authentication

--- a/backend/app/api/v1/endpoints/pipeline.py
+++ b/backend/app/api/v1/endpoints/pipeline.py
@@ -1,10 +1,13 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
+import asyncio, json
+from starlette.responses import StreamingResponse
 from ....schemas.pipeline import PipelineRequest, PipelineResponse
 from ....services.pipeline.pipeline import run_pipeline  # import the function directly
+from ....services.pipeline.quiz_generator import generate_quiz
+from ....services.pipeline.summarizer import stream_final_summary
 
 router = APIRouter()
 
-# Use empty path so both "/v1/pipeline" and "/v1/pipeline/" work without redirects
 @router.post("", response_model=PipelineResponse, summary="Run full text processing pipeline")
 def run_pipeline_endpoint(request: PipelineRequest) -> PipelineResponse:
     """
@@ -16,3 +19,39 @@ def run_pipeline_endpoint(request: PipelineRequest) -> PipelineResponse:
     except Exception as exc:
         # Return a friendly HTTP error
         raise HTTPException(status_code=500, detail=f"Pipeline processing failed: {str(exc)}")
+
+@router.post("/stream-chunks")
+async def pipeline_stream_chunks(request: Request):
+    """One-way HTTP streaming using NDJSON (application/x-ndjson)."""
+    body = await request.json()
+    text = (body.get("text") or "").strip()
+    if not text:
+        # Return JSON error immediately
+        return StreamingResponse((chunk for chunk in [json.dumps({"type": "error", "detail": "Missing 'text'"}) + "\n"]), media_type="application/x-ndjson")
+
+    async def event_generator():
+        try:
+            yield json.dumps({"type": "start"}) + "\n"
+
+            # Stream final summary using the exact same flow as summarize_text
+            streamed_parts = []
+            async for seg in stream_final_summary(text):
+                streamed_parts.append(seg)
+                yield json.dumps({"type": "summary_chunk", "content": seg}) + "\n"
+
+            yield json.dumps({"type": "summary_complete"}) + "\n"
+
+            full_summary = "".join(streamed_parts)
+            quiz = await asyncio.to_thread(generate_quiz, full_summary)
+            yield json.dumps({"type": "quiz", "quiz": [q.model_dump() for q in quiz]}) + "\n"
+
+            yield json.dumps({"type": "done"}) + "\n"
+        except Exception as exc:
+            yield json.dumps({"type": "error", "detail": str(exc)}) + "\n"
+
+    response = StreamingResponse(event_generator(), media_type="application/x-ndjson")
+    response.headers["Cache-Control"] = "no-cache, no-transform"
+    response.headers["X-Accel-Buffering"] = "no"
+    response.headers["Connection"] = "keep-alive"
+    # Avoid explicitly setting Transfer-Encoding; let ASGI/server decide to reduce aborts
+    return response

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -8,6 +8,8 @@ A single-page application for the **TLDR** backend, built with **React**, **Vite
 - **Live rendering** of summaries with Markdown styling
 - **Quiz display** from structured backend JSON
 - **Dev Proxy** in `vite.config.js` routes `/api/*` to `http://localhost:8000/*`
+- **Streaming UI** updates for partial summaries
+
 
 ## 🛠️ Tech Stack
 
@@ -27,6 +29,5 @@ pnpm dev
 Visit: [http://localhost:5173](http://localhost:5173)
 
 ## 🔮 Future Enhancements
-- Streaming UI updates for partial summaries
 - Mobile-optimized layout
 - Document handling for reports, presentations, spreadsheets

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,15 +1,19 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8001',
+        target: 'http://localhost:8000',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ''),
+        configure: (proxy) => {
+          proxy.on('proxyReq', (proxyReq) => {
+            proxyReq.setHeader('Connection', 'keep-alive')
+          })
+        },
       },
     },
   },


### PR DESCRIPTION
# PR: Streamed Summary + Quiz (NDJSON)

## Backend
- Add `POST /v1/pipeline/stream-chunks` (NDJSON):  
  `start → summary_chunk* → summary_complete → quiz → done`
- Stream final merge in `summarizer.py` using the same prompts/flow:  
  Split → summarize chunks (non-stream) → merge (OpenAI streaming)
- Remove WebSocket and temp test route; delete duplicate streaming module
- Set `no-cache` headers to reduce buffering

## Frontend
- Add `openPipelineStream` (fetch + `ReadableStream`) to parse NDJSON
- Disable submit while streaming; show progress immediately
- Automatic fallback to `POST /v1/pipeline` on stream error

## Notes
- Non-stream endpoint unchanged
- No schema changes; quiz shape is consistent